### PR TITLE
add required parameter invert_colors: false

### DIFF
--- a/wt32sc01a.yaml
+++ b/wt32sc01a.yaml
@@ -257,6 +257,7 @@ display:
     dc_pin: GPIO21
     reset_pin: GPIO22
     rotation: 90
+    invert_colors: false
     pages:
       - id: klok5
         lambda: |-

--- a/wt32sc01b.yaml
+++ b/wt32sc01b.yaml
@@ -257,6 +257,7 @@ display:
     dc_pin: GPIO21
     reset_pin: GPIO22
     rotation: 90
+    invert_colors: false
     pages:
       - id: klok5
         lambda: |-


### PR DESCRIPTION
Using ESPHome 2024.12.2 the parameter invert_colors is mandatory.